### PR TITLE
fix: logger创建目录时需要加上recursive

### DIFF
--- a/packages/main/utils/logger.ts
+++ b/packages/main/utils/logger.ts
@@ -9,7 +9,7 @@ import { getAppBaseDir } from './path'
 class Logger {
   public constructor() {
     if (!existsSync(this.log_file_dir_)) {
-      mkdirSync(this.log_file_dir_)
+      mkdirSync(this.log_file_dir_, { recursive: true })
     }
 
     const date = format(new Date(), 'yyyyMMdd')


### PR DESCRIPTION
![image](https://github.com/MaaAssistantArknights/MaaX/assets/36261034/33160d62-01ef-47d1-8f6e-a5574c3cb918)
pnpm dev时创建logger文件夹时要加上recursive