### PR TITLE
CI：更新CI action版本，添加开发版本构建物上传

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         node: ["20"]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        arch: ["amd64", "arm64"]
+        arch: ["x64", "arm64"]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_OPTIONS: "--max_old_space_size=6144"
@@ -51,3 +51,8 @@ jobs:
 
       - name: Compile Electron app
         run: pnpm make
+
+      - name: Publish to mirrors
+        run: pnpm run publish --arch=${{ matrix.arch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -25,23 +25,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ["18"]
+        node: ["20"]
         os: [windows-latest, ubuntu-latest, macos-latest]
         arch: ["amd64", "arm64"]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_OPTIONS: "--max_old_space_size=6144"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
           version: latest
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Compile Electron app
         run: pnpm make
 
-      - name: Publish to mirrors
-        run: pnpm run publish --arch=${{ matrix.arch }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: maax-nightly-${{ matrix.os }}-${{ matrix.arch }}
+          path: ./out/maa-x*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         node: ["20"]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        arch: ["amd64", "arm64"]
+        arch: ["x64", "arm64"]
     steps:
       - name: Enable long path support on windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,25 +51,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["18"]
+        node: ["20"]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        arch: ["x64", "arm64"]
+        arch: ["amd64", "arm64"]
     steps:
       - name: Enable long path support on windows
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
           version: latest
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"


### PR DESCRIPTION
目前使用旧版action会在ci上出现一些警告信息，更新版本可以解决

添加 dev 分支构建物上传到actions内，方便下载最新构建物，具体效果可以参考 [ci结果](https://github.com/dragove/MaaX/actions/runs/7949780296)