### PR TITLE
添加可调试的启动方式

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -93,7 +93,7 @@
       "name": "Renderer(DEBUG)",
       "configurations": [
         "Serve(inspector)",
-        "Main(inspector)",
+        "Renderer(inspector)",
       ],
       "preLaunchTask": ""
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,19 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Serve(inspector)",
+      "request": "launch",
+      "runtimeArgs": [
+        "scripts/serve.mjs"
+      ],
+      "runtimeExecutable": "node",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
+    },
+    
+    {
       "type": "node",
       "request": "launch",
       "name": "Main(inspector)",
@@ -51,6 +64,14 @@
     },
   ],
   "compounds": [
+    {
+      "name": "DEBUG",
+      "configurations": [
+        "Serve(inspector)",
+        "Main(inspector)",
+      ],
+      "preLaunchTask": ""
+    },
     {
       "name": "All(inspector)",
       "configurations": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "type": "node"
+      "type": "node",
+      "sourceMaps": true
     },
     
     {
@@ -21,6 +22,7 @@
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
       "runtimeArgs": [
         "--remote-debugging-port=9222",
+        "--remote-allow-origins=*",
         "${workspaceFolder}/dist/main/index.cjs",
       ],
       "env": {
@@ -35,8 +37,21 @@
       "type": "chrome",
       "request": "launch",
       "name": "Renderer(inspector)",
-      "url": "http://localhost:9222",
-      "webRoot": "${workspaceFolder}/dist/packages/renderer",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+      "runtimeArgs": [
+        "--remote-debugging-port=9222",
+        "--remote-allow-origins=*",
+        "${workspaceFolder}/dist/main/index.cjs",
+      ],
+      "env": {
+        "DEBUG": "true",
+      },
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
+      "sourceMaps": true,
+      "url": "http://localhost:3344",
+      "webRoot": "${workspaceFolder}/packages/renderer",
     },
     {
       "type": "node",
@@ -45,6 +60,8 @@
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
       "runtimeArgs": [
         "${workspaceFolder}/dist/main/index.cjs",
+        "--remote-debugging-port=9222",
+        "--remote-allow-origins=*",
       ],
       "env": {
         "VITE_DEV_SERVER_HOST": "127.0.0.1",
@@ -65,7 +82,15 @@
   ],
   "compounds": [
     {
-      "name": "DEBUG",
+      "name": "main(DEBUG)",
+      "configurations": [
+        "Serve(inspector)",
+        "Main(inspector)",
+      ],
+      "preLaunchTask": ""
+    },
+    {
+      "name": "Renderer(DEBUG)",
       "configurations": [
         "Serve(inspector)",
         "Main(inspector)",

--- a/scripts/serve.mjs
+++ b/scripts/serve.mjs
@@ -1,0 +1,30 @@
+import { build, createServer } from 'vite'
+
+/**
+ * @type {(server: import('vite').ViteDevServer) => Promise<import('rollup').RollupWatcher>}
+ */
+function watchPreload(server) {
+  return build({
+    configFile: 'packages/preload/vite.config.ts',
+    mode: 'development',
+    plugins: [
+      {
+        name: 'electron-preload-watcher',
+        writeBundle() {
+          server.ws.send({ type: 'full-reload' })
+        },
+      },
+    ],
+    build: {
+      watch: true,
+    },
+  })
+}
+
+// bootstrap
+const server = await createServer({
+  configFile: 'packages/renderer/vite.config.ts',
+})
+
+await server.listen()
+await watchPreload(server)


### PR DESCRIPTION
新版本的vscode无法按照readme中的方式进行调试，在launch.json中增加了一个可以供vscode使用的调试方式
需要调试main，在vscode的调试与执行中运行main(DEBUG)，调试Renderer，在vscode的调试与执行中运行Renderer(DEBUG)
