### PR TITLE
fix ci build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: pnpm/action-setup@v3
         with:
-          version: latest
+          version: 8
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4

--- a/packages/renderer/src/utils/game_image.ts
+++ b/packages/renderer/src/utils/game_image.ts
@@ -4,7 +4,7 @@ const baseUrl = 'https://media.prts.wiki'
 
 const getFileUrl = (filename: string): string => {
   const hash = String(MD5(filename))
-  return `${baseUrl}/${hash[0]}/${hash.substring(0, 1)}/${filename}`
+  return `${baseUrl}/${hash[0]}/${hash.substring(0, 2)}/${filename}`
 }
 
 export const getOperatorAvatar = (operatorCode: string): string =>


### PR DESCRIPTION
- pnpm 升级了，导致CI都失败了。ci 中指定了pnpm 版本为 8
- 窗口没有关闭按钮，猜测是 frame 的设置问题，修改为非windows环境中frame都设置为true
- prts.wiki 的图片链接更新了，地址拼接中的 substring(0, 2) 改了回来，需要截取2位